### PR TITLE
fix token only bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ drivers/ansible_shell.zip
 *.zip
 .vscode/
 venv
+.venv*
 dist/

--- a/package/cloudshell/cm/ansible/ansible_shell.py
+++ b/package/cloudshell/cm/ansible/ansible_shell.py
@@ -119,7 +119,7 @@ class AnsibleShell(object):
         """
         repo = ansi_conf.playbook_repo
         auth = None
-        if ansi_conf.playbook_repo.username:
+        if ansi_conf.playbook_repo.username or ansi_conf.playbook_repo.token:
             auth = HttpAuth(repo.username, repo.password, repo.token)
         playbook_name = self.downloader.get(ansi_conf.playbook_repo.url, auth, logger, cancellation_sampler)
         logger.info('download playbook file' + str(playbook_name))


### PR DESCRIPTION
align with custom shell script - allow to use "only token" for download.
also fixing .gitignore to handle all venvs. 