### PR TITLE
Ignore server certificate

### DIFF
--- a/drivers/ansible_shellPackage/DataModel/datamodel.xml
+++ b/drivers/ansible_shellPackage/DataModel/datamodel.xml
@@ -13,6 +13,8 @@
     </AttributeInfo>
     <AttributeInfo Name="Timeout Minutes" Type="Numeric" DefaultValue="0" Description="Maximum number of minutes to connect to the target machine." IsReadOnly="false">
     </AttributeInfo>
+    <AttributeInfo Name="Verify Certificate" Type="String" DefaultValue="True" 
+      Description="Verify server certificate when getting script if True, otherwise ignore." IsReadOnly="false">
   </Attributes>
   <ResourceFamilies>
     <ResourceFamily Name="Configuration Services" Description="" IsAdminOnly="true" IsService="true" ServiceType="Regular">
@@ -34,12 +36,14 @@
               <AllowedValues />
             </AttachedAttribute>
             <AttachedAttribute Name="Timeout Minutes" IsLocal="true" IsOverridable="true"/>
+            <AttachedAttribute Name="Verify Certificate" IsLocal="true" IsOverridable="true" />
           </AttachedAttributes>
           <AttributeValues>
             <AttributeValue Name="Ansible Additional Arguments" Value="" />
             <AttributeValue Name="Supports Ansible" Value="True" />
             <AttributeValue Name="Execution Server Selector" Value="" />
             <AttributeValue Name="Timeout Minutes" Value="20" />
+            <AttributeValue Name="Verify Certificate" Value="True" />
           </AttributeValues>
           <ParentModels />
           <Drivers>

--- a/drivers/ansible_shellPackage/DataModel/datamodel.xml
+++ b/drivers/ansible_shellPackage/DataModel/datamodel.xml
@@ -15,6 +15,7 @@
     </AttributeInfo>
     <AttributeInfo Name="Verify Certificate" Type="String" DefaultValue="True" 
       Description="Verify server certificate when getting script if True, otherwise ignore." IsReadOnly="false">
+      </AttributeInfo>
   </Attributes>
   <ResourceFamilies>
     <ResourceFamily Name="Configuration Services" Description="" IsAdminOnly="true" IsService="true" ServiceType="Regular">

--- a/package/cloudshell/cm/ansible/ansible_shell.py
+++ b/package/cloudshell/cm/ansible/ansible_shell.py
@@ -125,7 +125,7 @@ class AnsibleShell(object):
         logger.info('Verify certificate: ' + str(ansi_conf.verify_certificate))
         playbook_name = self.downloader.get(ansi_conf.playbook_repo.url, 
                                             auth, logger, cancellation_sampler, 
-                                            ansi_conf.verify_certificate, ansi_conf.verify_certificate)
+                                            ansi_conf.verify_certificate)
         logger.info('download playbook file' + str(playbook_name))
         return playbook_name
 

--- a/package/cloudshell/cm/ansible/ansible_shell.py
+++ b/package/cloudshell/cm/ansible/ansible_shell.py
@@ -121,7 +121,11 @@ class AnsibleShell(object):
         auth = None
         if ansi_conf.playbook_repo.username or ansi_conf.playbook_repo.token:
             auth = HttpAuth(repo.username, repo.password, repo.token)
-        playbook_name = self.downloader.get(ansi_conf.playbook_repo.url, auth, logger, cancellation_sampler)
+
+        logger.info('Verify certificate: ' + str(ansi_conf.verify_certificate))
+        playbook_name = self.downloader.get(ansi_conf.playbook_repo.url, 
+                                            auth, logger, cancellation_sampler, 
+                                            ansi_conf.verify_certificate, ansi_conf.verify_certificate)
         logger.info('download playbook file' + str(playbook_name))
         return playbook_name
 

--- a/package/cloudshell/cm/ansible/domain/ansible_configuration.py
+++ b/package/cloudshell/cm/ansible/domain/ansible_configuration.py
@@ -15,6 +15,7 @@ class AnsibleConfiguration(object):
         self.playbook_repo = playbook_repo or PlaybookRepository()
         self.hosts_conf = hosts_conf or []
         self.additional_cmd_args = additional_cmd_args
+        self.verify_certificate = True
 
 
 class PlaybookRepository(object):
@@ -57,6 +58,7 @@ class AnsibleConfigurationParser(object):
         ansi_conf = AnsibleConfiguration()
         ansi_conf.additional_cmd_args = json_obj.get('additionalArgs')
         ansi_conf.timeout_minutes = json_obj.get('timeoutMinutes', 0.0)
+        ansi_conf.verify_certificate = json_obj.get('verifyCertificate', 'true').lower()=='true'
 
         if json_obj.get('repositoryDetails'):
             ansi_conf.playbook_repo.url = json_obj['repositoryDetails'].get('url')

--- a/package/cloudshell/cm/ansible/domain/http_request_service.py
+++ b/package/cloudshell/cm/ansible/domain/http_request_service.py
@@ -2,8 +2,8 @@ import requests
 
 
 class HttpRequestService(object):
-    def get_response(self, url, auth):
-        return requests.get(url, auth=(auth.username, auth.password) if auth else None, stream=True)
+    def get_response(self, url, auth, verify_certificate):
+        return requests.get(url, auth=(auth.username, auth.password) if auth else None, stream=True, verify=verify_certificate)
     
-    def get_response_with_headers(self, url, headers):
-        return requests.get(url, headers=headers, stream=True)
+    def get_response_with_headers(self, url, headers, verify_certificate):
+        return requests.get(url, headers=headers, stream=True, verify=verify_certificate)

--- a/package/cloudshell/cm/ansible/domain/playbook_downloader.py
+++ b/package/cloudshell/cm/ansible/domain/playbook_downloader.py
@@ -23,30 +23,32 @@ class PlaybookDownloader(object):
         self.http_request_service = http_request_service
         self.filename_extractor = filename_extractor
 
-    def get(self, url, auth, logger, cancel_sampler):
+    def get(self, url, auth, logger, cancel_sampler, verify_certificate):
         """
         Download the file from the url (unzip if needed).
         :param str url: Http url of the file.
         :param HttpAuth auth: Authentication to the http server (optional).
         :param Logger logger:
         :param CancellationSampler cancel_sampler:
+        :param boolean verify_certificate:
         :rtype [str,int]
         :return The downloaded playbook file name
         """
-        file_name, file_size = self._download(url, auth, logger, cancel_sampler)
+        file_name, file_size = self._download(url, auth, logger, cancel_sampler, verify_certificate)
 
         if file_name.endswith(".zip"):
             file_name = self._unzip(file_name, logger)
 
         return file_name
 
-    def _download(self, url, auth, logger, cancel_sampler):
+    def _download(self, url, auth, logger, cancel_sampler, verify_certificate):
         """
         Download the file from the url.
         :param str url: Http url of the file.
         :param HttpAuth auth: Authentication to the http server (optional).
         :param Logger logger:
         :param CancellationSampler cancel_sampler:
+        :param boolean verify_certificate:
         :rtype [str,int]
         :return The downloaded file name
         """
@@ -55,7 +57,7 @@ class PlaybookDownloader(object):
         
         # assume repo is public, try to download without credentials
         logger.info('Starting download script as public... from \'%s\' ...'%url)
-        response = self.http_request_service.get_response(url, auth)
+        response = self.http_request_service.get_response(url, auth, verify_certificate)
         response_valid = self._is_response_valid(logger ,response, "public")
 
         if response_valid:
@@ -65,7 +67,7 @@ class PlaybookDownloader(object):
         if not response_valid and auth.token is not None:
             logger.info("Token provided. Starting download script with Token...")
             headers = {"Authorization": "Bearer %s" % auth.token }
-            response = self.http_request_service.get_response_with_headers(url, headers)
+            response = self.http_request_service.get_response_with_headers(url, headers, verify_certificate)
             
             response_valid = self._is_response_valid(logger, response, "Token")
 
@@ -75,7 +77,7 @@ class PlaybookDownloader(object):
         # repo is private and credentials provided, and Token did not provided or did not work. this will NOT work for github. github require Token
         if not response_valid and (auth.username is not None and auth.password is not None):
             logger.info("username\password provided, Starting download script with username\password...")
-            response = self.http_request_service.get_response(url, auth)
+            response = self.http_request_service.get_response(url, auth, verify_certificate)
 
             response_valid = self._is_response_valid(logger, response, "username\password")
 

--- a/package/tests/test_ansible_shell.py
+++ b/package/tests/test_ansible_shell.py
@@ -198,7 +198,7 @@ class TestAnsibleShell(TestCase):
 
         self._execute_playbook()
 
-        self.downloader.get.assert_called_once_with('someurl', Any(), Any(), Any())
+        self.downloader.get.assert_called_once_with('someurl', Any(), Any(), Any(), True)
 
     def test_download_playbook_with_auth(self):
         self.conf.playbook_repo.url = 'someurl'
@@ -209,7 +209,7 @@ class TestAnsibleShell(TestCase):
 
         self.downloader.get.assert_called_once_with('someurl',
                                                     Any(lambda x: x.username == 'user' and x.password == 'pass'), Any(),
-                                                    Any())
+                                                    Any(), True)
 
     # Playbook Executor
 

--- a/package/tests/test_playbook_downloader.py
+++ b/package/tests/test_playbook_downloader.py
@@ -35,7 +35,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(return_value=True)
 
-        file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+        file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
         self.assertEqual(file_name, "lie.yaml")
 
 
@@ -50,7 +50,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(return_value=True)
 
-        file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+        file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
         self.assertEqual(file_name, "site.yaml")
 
@@ -65,7 +65,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(return_value=True)
         with self.assertRaises(Exception) as e:
-            self.playbook_downloader.get("", auth, self.logger, Mock())
+            self.playbook_downloader.get("", auth, self.logger, Mock(), True)
         self.assertEqual(str(e.exception),"Playbook file name was not found in zip file")
 
     def test_playbook_downloader_with_one_yaml(self):
@@ -78,7 +78,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(return_value=True)
 
-        file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+        file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
         self.assertEqual(file_name, "lie.yaml")
 
@@ -92,7 +92,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(return_value=True)
         
-        file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+        file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
         self.assertEqual(file_name, "lie.yaml")
     
@@ -106,7 +106,7 @@ class TestPlaybookDownloader(TestCase):
         self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
         self.playbook_downloader._is_response_valid = Mock(side_effect=self.mock_response_valid_for_credentials)
 
-        file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+        file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
         self.assertEqual(file_name, "lie.yaml")
 
@@ -120,7 +120,7 @@ class TestPlaybookDownloader(TestCase):
             self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
             self.playbook_downloader._is_response_valid = Mock(side_effect=self.mock_response_valid_for_not_public)
 
-            file_name = self.playbook_downloader.get("", auth, self.logger, Mock())
+            file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
             self.assertEqual(file_name, "lie.yaml")
     


### PR DESCRIPTION
allow ansible configuration service to be configured to ignore server certificates (skip check) if set the service attribute (on the resource model) to Verify Certificate: "False"