### PR TITLE
adding private-token and test

### DIFF
--- a/package/cloudshell/cm/ansible/domain/playbook_downloader.py
+++ b/package/cloudshell/cm/ansible/domain/playbook_downloader.py
@@ -74,6 +74,17 @@ class PlaybookDownloader(object):
             if response_valid:
                 file_name = self.filename_extractor.get_filename(response)
 
+        # try again with authorization {"Private-Token": "%s" % token}, since gitlab uses that pattern
+        if not response_valid and auth.token is not None:
+            logger.info("Token provided. Starting download script with Token (private-token pattern)...")
+            headers = {"Private-Token": "Bearer %s" % auth.token }
+            response = self.http_request_service.get_response_with_headers(url, headers, verify_certificate)
+            
+            response_valid = self._is_response_valid(logger, response, "Token")
+
+            if response_valid:
+                file_name = self.filename_extractor.get_filename(response)
+
         # repo is private and credentials provided, and Token did not provided or did not work. this will NOT work for github. github require Token
         if not response_valid and (auth.username is not None and auth.password is not None):
             logger.info("username\password provided, Starting download script with username\password...")

--- a/package/tests/test_playbook_downloader.py
+++ b/package/tests/test_playbook_downloader.py
@@ -124,13 +124,26 @@ class TestPlaybookDownloader(TestCase):
 
             self.assertEqual(file_name, "lie.yaml")
     
+    def test_playbook_downloader_with_one_yaml_only_token_with_auth_private_token(self):
+            auth = HttpAuth(None, None, "Token")        
+            self.reqeust.url = "blabla/lie.yaml"
+            dic = dict([('content-disposition', 'lie.yaml'), ('Private-Token', 'Token')])
+            self.reqeust.headers = dic
+            self.reqeust.iter_content.return_value = 'hello'
+            self.http_request_serivce.get_response = Mock(return_value=self.reqeust)
+            self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
+            self.playbook_downloader._is_response_valid = Mock(side_effect=self.mock_response_valid_for_private_token)
 
+            file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
+            self.assertEqual(file_name, "lie.yaml")
 
     # helpers method to mock the request according the request in order to test the right flow for Token\Cred
     def mock_response_valid_for_not_public(self, logger, response, request_method):
         return request_method != "public"
             
-    
     def mock_response_valid_for_credentials(self, logger, response, request_method):
         return request_method == "username\password"
+
+    def mock_response_valid_for_private_token(self, logger, response, request_method):
+        return 'Private-Token' in response.headers


### PR DESCRIPTION
PBI 180193 - need to support gitlab and bitbucket. added a method just for gitlab pattern ('private-token') since current implementation should work for bitbucket and github in the current form