### PR TITLE
fix for get filename from gitlab url structure

### DIFF
--- a/package/cloudshell/cm/ansible/domain/filename_extractor.py
+++ b/package/cloudshell/cm/ansible/domain/filename_extractor.py
@@ -24,7 +24,15 @@ class FilenameExtractor(object):
             file_name_from_url = urllib.parse.unquote(response.url[response.url.rfind('/') + 1:])
             matching = re.match(self._filename_pattern, file_name_from_url)
             if matching:
+                file_name = matching.group('filename')        
+        
+        # fallback, couldn't find file name regular URL, check gitlab structure (filename in [-2] position)
+        if not file_name:
+            file_name_from_url = urllib.parse.unquote(response.url.split('/')[-2])
+            matching = re.match(self._filename_pattern, file_name_from_url)
+            if matching:
                 file_name = matching.group('filename')
+
         if not file_name:
             raise AnsibleException("playbook file of supported types: '.yml', '.yaml', '.zip' was not found")
         return file_name.strip()

--- a/package/tests/test_filename_extractor.py
+++ b/package/tests/test_filename_extractor.py
@@ -34,6 +34,14 @@ class TestFilenameExtractor(TestCase):
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(), extracted_filename)
 
+    def test_filename_from_url_gitlab_structure(self):
+        filename = "  my_file.zip  "
+        header = {}
+        self.response.headers = header
+        self.response.url = "http://www.template.myurl/a/b/my_file%2Ezip/raw?ref=master"
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename.strip(), extracted_filename)
+
     def test_unsupported_playbook_file(self):
         filename = "  my_file.exe  "
         header = {}


### PR DESCRIPTION
gitlab url is different - filename is not the last item on the string, its the next to last. so added another fallback in the filename extractor to check for that, in case all other attepts failed. also added a test to verify.