### PR TITLE
add exception on auth=none and public fails

### DIFF
--- a/package/cloudshell/cm/ansible/domain/playbook_downloader.py
+++ b/package/cloudshell/cm/ansible/domain/playbook_downloader.py
@@ -63,6 +63,10 @@ class PlaybookDownloader(object):
         if response_valid:
             file_name = self.filename_extractor.get_filename(response)
 
+        # if fails on public and no auth - no point carry on, user need to fix his URL or add credentials
+        if not response_valid and auth is None:
+            raise Exception('Please make sure the URL is valid, and the credentials are correct and necessary.')
+
         # repo is private and token provided
         if not response_valid and auth.token is not None:
             logger.info("Token provided. Starting download script with Token...")

--- a/package/tests/test_playbook_downloader.py
+++ b/package/tests/test_playbook_downloader.py
@@ -137,6 +137,22 @@ class TestPlaybookDownloader(TestCase):
             file_name = self.playbook_downloader.get("", auth, self.logger, Mock(), True)
 
             self.assertEqual(file_name, "lie.yaml")
+    
+    def test_playbook_downloader_fails_on_public_and_no_credentials(self):
+        auth = None
+        self.reqeust.url = "blabla/lie.zip"
+        dic = dict([('content-disposition', 'lie.zip')])
+        self.reqeust.headers = dic
+        self.reqeust.iter_content.return_value = ''
+        self.http_request_serivce.get_response = Mock(return_value=self.reqeust)
+        self.http_request_serivce.get_response_with_headers = Mock(return_value=self.reqeust)
+        self.playbook_downloader._is_response_valid = Mock(return_value=False)
+
+        with self.assertRaises(Exception) as e:
+            self.playbook_downloader.get("", auth, self.logger, Mock(), True)
+
+        self.assertEqual(str(e.exception),"Please make sure the URL is valid, and the credentials are correct and necessary.")
+
 
     # helpers method to mock the request according the request in order to test the right flow for Token\Cred
     def mock_response_valid_for_not_public(self, logger, response, request_method):


### PR DESCRIPTION
for the use case of auth is none (user did not enter credentials) and the public download fails (URL is wrong) we should throw a nice exception and not "NoneType" - which was what happened since the auth wa None on the next download attempt. also added a test. 