### PR TITLE
wip/adam.s/181045_fix_regex_for_chars

### DIFF
--- a/package/cloudshell/cm/ansible/domain/filename_extractor.py
+++ b/package/cloudshell/cm/ansible/domain/filename_extractor.py
@@ -6,7 +6,7 @@ from cloudshell.cm.ansible.domain.exceptions import AnsibleException
 
 class FilenameExtractor(object):
     def __init__(self):
-        self._filename_pattern = "(?P<filename>\s*[\w,\s-]+\.(yaml|yml|zip)\s*)"
+        self._filename_pattern = r"(?P<filename>\s*([\w,\s-]*|^.*\.?[^/\\&\?]+)\.(yaml|yml|zip)\s*(?=([\?&].*$|$)))"
         self.filename_patterns = {
                 "content-disposition": "\s*((?i)inline|attachment|extension-token)\s*;\s*filename=" + self._filename_pattern,
                 "x-artifactory-filename": self._filename_pattern

--- a/package/tests/test_filename_extractor.py
+++ b/package/tests/test_filename_extractor.py
@@ -18,6 +18,12 @@ class TestFilenameExtractor(TestCase):
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(),extracted_filename)
 
+    def test_filename_from_header_RFC_content_disposition_no_spcaces(self):
+        filename = "my_file.yaml"
+        header = {'content-disposition': 'attachment ;  filename=' + filename}
+        self.response.headers = header
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename,extracted_filename)
 
     def test_filename_from_header_artifactory(self):
         filename = "  my_file.yml  "
@@ -25,6 +31,13 @@ class TestFilenameExtractor(TestCase):
         self.response.headers = header
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(), extracted_filename)
+
+    def test_filename_from_header_artifactory_no_spaces(self):
+        filename = "my_file.yml"
+        header = {'x-artifactory-filename': filename}
+        self.response.headers = header
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename, extracted_filename)
 
     def test_filename_from_url(self):
         filename = "  my_file.zip  "
@@ -34,6 +47,14 @@ class TestFilenameExtractor(TestCase):
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(), extracted_filename)
 
+    def test_filename_from_url_no_spaces(self):
+        filename = "my_file.zip"
+        header = {}
+        self.response.headers = header
+        self.response.url = "http://www.template.myurl/a/b/c/" + filename
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename, extracted_filename)
+
     def test_filename_from_url_gitlab_structure(self):
         filename = "  my_file.zip  "
         header = {}
@@ -41,6 +62,14 @@ class TestFilenameExtractor(TestCase):
         self.response.url = "http://www.template.myurl/a/b/my_file%2Ezip/raw?ref=master"
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(), extracted_filename)
+
+    def test_filename_from_url_gitlab_structure_speciel_chars(self):
+        filename = "a-b@c=d.yml"
+        header = {}
+        self.response.headers = header
+        self.response.url = "https://gitlab.com/api/v4/projects/25386685/repository/files/a-b%40c%3Dd.yml/raw?ref=master"
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename, extracted_filename)
 
     def test_unsupported_playbook_file(self):
         filename = "  my_file.exe  "
@@ -51,3 +80,11 @@ class TestFilenameExtractor(TestCase):
             self.filename_extractor.get_filename(self.response)
         self.assertEqual(str(unsupportedExc.exception),"playbook file of supported types: '.yml', '.yaml', '.zip' was not found")
 
+    def test_unsupported_playbook_file_no_spaces(self):
+        filename = "my_file.exe"
+        header = {}
+        self.response.headers = header
+        self.response.url = "http://www.template.myurl/a/b/c/" + filename
+        with self.assertRaises(Exception) as unsupportedExc:
+            self.filename_extractor.get_filename(self.response)
+        self.assertEqual(str(unsupportedExc.exception),"playbook file of supported types: '.yml', '.yaml', '.zip' was not found")

--- a/package/tests/test_filename_extractor.py
+++ b/package/tests/test_filename_extractor.py
@@ -47,6 +47,14 @@ class TestFilenameExtractor(TestCase):
         extracted_filename = self.filename_extractor.get_filename(self.response)
         self.assertEqual(filename.strip(), extracted_filename)
 
+    def test_filename_from_url_from_bitbucket(self):
+        filename = "simple.yml"
+        header = {}
+        self.response.headers = header
+        self.response.url = "http://192.168.30.96:7990/rest/api/1.0/projects/TEST/repos/test/raw/simple.yml"
+        extracted_filename = self.filename_extractor.get_filename(self.response)
+        self.assertEqual(filename, extracted_filename)
+
     def test_filename_from_url_no_spaces(self):
         filename = "my_file.zip"
         header = {}


### PR DESCRIPTION
the regex that exract the name was not good enough for filenames with speciel chars. changed it and added to tests to cover (hopefully) all the URL structure options. 