### PR TITLE
Fix ansible being not cancellable

### DIFF
--- a/package/cloudshell/cm/ansible/ansible_shell.py
+++ b/package/cloudshell/cm/ansible/ansible_shell.py
@@ -62,7 +62,7 @@ class AnsibleShell(object):
                     with TempFolderScope(self.file_system, logger):
                         self._add_ansible_config_file(logger)
                         self._add_host_vars_files(ansi_conf, logger)
-                        self._wait_for_all_hosts_to_be_deployed(ansi_conf, logger, output_writer)
+                        self._wait_for_all_hosts_to_be_deployed(ansi_conf, logger, output_writer, cancellation_sampler)
                         self._add_inventory_file(ansi_conf, logger)
                         playbook_name = self._download_playbook(ansi_conf, cancellation_sampler, logger)
                         self._run_playbook(ansi_conf, playbook_name, output_writer, cancellation_sampler, logger)
@@ -147,12 +147,13 @@ class AnsibleShell(object):
         if not ansible_result.success:
             raise AnsibleException(ansible_result.to_json())
 
-    def _wait_for_all_hosts_to_be_deployed(self, ansi_conf, logger, output_writer):
+    def _wait_for_all_hosts_to_be_deployed(self, ansi_conf, logger, output_writer, cancellation_sampler):
         """
 
         :param cloudshell.cm.ansible.domain.ansible_configurationa.AnsibleConfiguration ansi_conf:
         :param Logger logger:
         :param domain.ansible_command_executor.ReservationOutputWriter output_writer:
+        :param CancellationSampler cancellation_sampler:
         :return:
         """
         wait_for_deploy_msg = "Waiting for all hosts to deploy"
@@ -175,7 +176,7 @@ class AnsibleShell(object):
             output_writer.write("Waiting for host: " + host.ip)
             output_writer.write(port_ansible_port)
 
-            self.connection_service.check_connection(logger, host, ansible_port=ansible_port,
+            self.connection_service.check_connection(logger, host, cancellation_sampler,ansible_port=ansible_port,
                                                      timeout_minutes=ansi_conf.timeout_minutes)
 
         output_writer.write("Communication check completed.")

--- a/package/cloudshell/cm/ansible/domain/ansible_command_executor.py
+++ b/package/cloudshell/cm/ansible/domain/ansible_command_executor.py
@@ -1,6 +1,7 @@
 from subprocess import Popen, PIPE
 import time
 import os
+import signal
 from logging import Logger
 from cloudshell.api.cloudshell_api import CloudShellAPISession
 import re
@@ -29,7 +30,7 @@ class AnsibleCommandExecutor(object):
 
         logger.info('Running cmd \'%s\' ...' % shell_command)
         start_time = time.time()
-        process = Popen(shell_command, shell=True, stdout=PIPE, stderr=PIPE)
+        process = Popen(shell_command, shell=True, stdout=PIPE, stderr=PIPE, start_new_session=True)
         all_txt_err = ''
         all_txt_out = ''
 
@@ -48,7 +49,7 @@ class AnsibleCommandExecutor(object):
                     if process.poll() is not None:
                         break
                     if cancel_sampler.is_cancelled():
-                        process.kill()
+                        os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                         cancel_sampler.throw()
                     time.sleep(2)
 


### PR DESCRIPTION
Cancellation was broken in 2 different areas:
- if ansible task was already running our 'process.kill' didn't actually kill it and waited for the child process to end
- checking connection to target hosts was in a loop that doesn't end if cancel request was sent